### PR TITLE
Remove custom build command as App Platform runs build script by default

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,7 +1,6 @@
 name: sample-vuejs
 services:
-- build_command: yarn build
-  environment_slug: node-js
+- environment_slug: node-js
   github:
     branch: main
     deploy_on_push: true


### PR DESCRIPTION
## The Issue

App Platform runs `build` script from `package.json` to build the app.
If build_command is present in AppSpec, it runs this command after the build i.e. it runs the build script twice.

This PR fixes this by removing custom build command from the AppSpec.